### PR TITLE
Hide cramps from calendar display

### DIFF
--- a/src/components/CalendarDay.tsx
+++ b/src/components/CalendarDay.tsx
@@ -48,7 +48,7 @@ function CalendarDay({
   function getDayData() {
     const period = measurements.find(m => m.type === 'period');
     const bbt = measurements.find(m => m.type === 'bbt');
-    const symptoms = measurements.filter(m => m.type === 'cramps' || m.type === 'sore_breasts');
+    const symptoms = measurements.filter(m => m.type === 'sore_breasts'); // Exclude cramps from calendar display
 
     return {
       period: period ? (period.value as { option: string }).option : null,

--- a/src/components/__tests__/CalendarDay.test.tsx
+++ b/src/components/__tests__/CalendarDay.test.tsx
@@ -207,7 +207,8 @@ describe('CalendarDay', () => {
       
       render(<CalendarDay {...defaultProps} measurements={measurements} />);
       
-      const symptomElement = screen.getByText('2⚠');
+      // Only sore_breasts should be counted now (cramps are hidden from calendar)
+      const symptomElement = screen.getByText('1⚠');
       expect(symptomElement).toBeInTheDocument();
       expect(symptomElement).toHaveStyle({
         backgroundColor: 'rgb(255, 152, 0)',
@@ -259,7 +260,8 @@ describe('CalendarDay', () => {
       
       expect(screen.queryByText('🩸')).not.toBeInTheDocument();
       expect(screen.getByText('36.4°')).toBeInTheDocument();
-      expect(screen.getByText('1⚠')).toBeInTheDocument();
+      // Cramps are now hidden from calendar, so no symptom badge should appear
+      expect(screen.queryByText('1⚠')).not.toBeInTheDocument();
       
       // Should have border for non-period data
       const dayElement = screen.getByText('15').parentElement;

--- a/src/components/__tests__/CalendarDay.test.tsx
+++ b/src/components/__tests__/CalendarDay.test.tsx
@@ -233,7 +233,7 @@ describe('CalendarDay', () => {
       const measurements = [
         MockDataFactory.createPeriodMeasurement('2024-03-15', PERIOD_OPTIONS.MEDIUM),
         MockDataFactory.createBBTMeasurement('2024-03-15', 36.8),
-        MockDataFactory.createSymptomMeasurement('2024-03-15', 'cramps', SYMPTOM_SEVERITY.SEVERE)
+        MockDataFactory.createSymptomMeasurement('2024-03-15', 'sore_breasts', SYMPTOM_SEVERITY.SEVERE)
       ];
       
       render(<CalendarDay {...defaultProps} measurements={measurements} />);


### PR DESCRIPTION
Fixes #11

This PR implements the requested feature to hide cramps from the calendar display while maintaining the ability to record cramp data.

**Changes made:**
- Modified CalendarDay component to exclude cramps from symptoms filter
- Updated tests to reflect that only sore_breasts are now shown on calendar
- Cramps data is still recorded but no longer displayed in calendar view

Generated with [Claude Code](https://claude.ai/code)